### PR TITLE
feat(loan): add migration and model

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -2,7 +2,7 @@ import cors from 'cors'
 import express, { Express, Request, Response } from 'express'
 
 import { CustomError } from '@/core/errors/custom-error'
-import User from '@/infra/database/models/user'
+import Loan from '@/infra/database/models/loan'
 
 import { env } from '../config/env'
 import { connectToDatabase } from '../infra/database/sequelize'
@@ -18,11 +18,11 @@ app.use(
   }),
 )
 
-app.get('/users', async (req: Request, res: Response) => {
-  const users = await User.findAll()
+app.get('/loans', async (req: Request, res: Response) => {
+  const loans = await Loan.findAll()
 
   res.send({
-    users,
+    loans,
   })
 })
 

--- a/src/infra/database/migrations/20250608115447-create-loans.ts
+++ b/src/infra/database/migrations/20250608115447-create-loans.ts
@@ -1,0 +1,50 @@
+import { DataTypes, QueryInterface } from 'sequelize'
+
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.createTable('Loans', {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      bookId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Books',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      loanDate: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+    })
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.dropTable('Loans')
+  },
+}

--- a/src/infra/database/models/loan.ts
+++ b/src/infra/database/models/loan.ts
@@ -1,0 +1,43 @@
+import {
+  BelongsTo,
+  Column,
+  DataType,
+  ForeignKey,
+  Model,
+  Table,
+} from 'sequelize-typescript'
+
+import { Book } from './book'
+import { User } from './user'
+
+@Table({ tableName: 'Loans' })
+export class Loan extends Model {
+  @ForeignKey(() => User)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  userId!: number
+
+  @ForeignKey(() => Book)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  bookId!: number
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  loanDate!: Date
+
+  @BelongsTo(() => User)
+  user!: User
+
+  @BelongsTo(() => Book)
+  book!: Book
+}
+
+export default Loan


### PR DESCRIPTION
Description

Adds the migration for the loans table in the database and implements the corresponding model for data manipulation. This feature enables the creation and initial listing of loans in the system.

Changes Made

Loans Table Migration: Created migration for the loans table with fields userId, bookId, loanDate, createdAt and updatedAt.
Loan Model: Added Loan model for interacting with the users table in the backend.
Listing Endpoint: Implemented GET /loans endpoint that returns an empty list { loans: [] } when no records exist.

How to Test

Run the database migrations: pnpm run migrate

Start the local server: pnpm run dev

Access http://localhost:3333/loans in a browser or using a tool like Postman.

Verify the response is:{ "loans": [] }

Additional Notes

The migration was tested in a PostgreSQL database environment.
Recommend reviewing the users table structure to ensure it meets project requirements.