### PR TITLE
Feature: Implement Get Book by ID Endpoint

### DIFF
--- a/src/http/controllers/get-book.ts
+++ b/src/http/controllers/get-book.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { CustomError } from '@/core/errors/custom-error'
+import Book from '@/infra/database/models/book'
+
+export async function getBook(req: Request, res: Response) {
+  const getBookParamsSchema = z.object({
+    id: z.coerce.number(),
+  })
+
+  const { id } = getBookParamsSchema.parse(req.params)
+
+  const book = await Book.findByPk(id)
+
+  if (!book) {
+    throw new CustomError('Book not found', 404)
+  }
+
+  res.send({
+    book,
+  })
+}

--- a/src/http/routes.ts
+++ b/src/http/routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 
 import { createBook } from './controllers/create-book'
+import { getBook } from './controllers/get-book'
 import { listBooks } from './controllers/list-books'
 
 export const router = Router({
@@ -8,4 +9,5 @@ export const router = Router({
 })
 
 router.get('/books', listBooks)
+router.get('/books/:id', getBook)
 router.post('/books', createBook)


### PR DESCRIPTION
## Description

This Pull Request introduces the functionality to retrieve a single book by its unique ID. It adds a new API endpoint, along with robust validation for the ID parameter and appropriate error handling for cases where the book is not found. This enhancement significantly improves the ability to query specific book details.

## Changes Made

- **Get Book by ID Controller:**
    - Created `getBook` controller to handle fetching a single book record.
    - Implemented Zod validation for the `id` parameter, ensuring it's a valid number.
    - Uses `Book.findByPk` to efficiently query the database by primary key.
    - Throws a `CustomError` with a `404 Not Found` status if no book matches the given ID.
- **API Endpoint:**
    - Added `GET /books/:id` route to the existing book router.
    - This route is now handled by the `getBook` controller.

## How to Test

1.  Ensure all project dependencies are installed with `pnpm install`.
2.  Run the database migrations (if not already applied) using `pnpm run migrate`.
3.  Start the application server:

    ```bash
    pnpm run dev
    ```

5.  **Successful Retrieval (Existing Book):**
    *   First, create a book using `POST /books` (if you don't have any data yet) to get an `id`.
        Example body: `{"title": "The Hitchhiker's Guide to the Galaxy", "author": "Douglas Adams", "ISBN": "9780345391803", "year": "1979"}`. Note the `id` from the response.
    *   Send a `GET` request to `http://localhost:3333/books/<book_id>` (replace `<book_id>` with an actual ID).
    *   Verify the response status is `200 OK` and the response body contains the details of the requested book.
6.  **Book Not Found (Non-existent ID):**
    *   Send a `GET` request to `http://localhost:3333/books/99999` (or any non-existent ID).
    *   Verify the response status is `404 Not Found` and the error message is `Book not found`.
7.  **Invalid ID Parameter (Non-numeric):**
    *   Send a `GET` request to `http://localhost:3333/books/abc`.
    *   Verify the response status is `400 Bad Request` and the error message reflects a Zod validation error for the `id` parameter.

## Issues Related

N/A
