### PR TITLE
Feature: Implement Get User by ID Endpoint

### DIFF
--- a/src/http/controllers/get-user.ts
+++ b/src/http/controllers/get-user.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { CustomError } from '@/core/errors/custom-error'
+import { User } from '@/infra/database/models/user'
+
+export async function getUser(req: Request, res: Response) {
+  const getUserParamsSchema = z.object({
+    id: z.coerce.number(),
+  })
+
+  const { id } = getUserParamsSchema.parse(req.params)
+
+  const user = await User.findByPk(id)
+
+  if (!user) {
+    throw new CustomError('User not found', 404)
+  }
+
+  res.send({
+    user,
+  })
+}

--- a/src/http/routes.ts
+++ b/src/http/routes.ts
@@ -4,6 +4,7 @@ import { createBook } from './controllers/create-book'
 import { createUser } from './controllers/create-user'
 import { deleteBook } from './controllers/delete-book'
 import { getBook } from './controllers/get-book'
+import { getUser } from './controllers/get-user'
 import { listBooks } from './controllers/list-books'
 import { listUsers } from './controllers/list-users'
 import { updateBook } from './controllers/update-book'
@@ -19,4 +20,5 @@ router.put('/books/:id', updateBook)
 router.delete('/books/:id', deleteBook)
 
 router.get('/users', listUsers)
+router.get('/users/:id', getUser)
 router.post('/users', createUser)


### PR DESCRIPTION
## Description

This Pull Request introduces the functionality to retrieve a single user account by its unique ID. It adds a new API endpoint, along with robust validation for the ID parameter and appropriate error handling for cases where the user is not found. This enhancement improves the ability to query specific user details.

## Changes Made

- **Get User by ID Controller:**
    - Created `getUser` controller to handle fetching a single user record.
    - Implemented Zod validation for the `id` parameter, ensuring it's a valid number.
    - Uses `User.findByPk` to efficiently query the database by primary key.
    - Throws a `CustomError` with a `404 Not Found` status if no user matches the given ID.
- **API Endpoint:**
    - Added `GET /users/:id` route to the main application router.
    - This route is now handled by the `getUser` controller.

## How to Test

1.  Ensure all project dependencies are installed with `pnpm install`.
2.  Run the database migrations (if not already applied) using `pnpm run migrate`.
3.  Start the application server:
    
    ```bash
    pnpm run dev
    ```

4.  **Successful Retrieval (Existing User):**
    *   First, create a user using `POST /users` (if you don't have any data yet) to get an `id`.
        Example body: `{"name": "Jane Doe", "email": "jane.doe@example.com", "phone": "5511999998888"}`. Note the `id` from the response.
    *   Send a `GET` request to `http://localhost:3333/users/<user_id>` (replace `<user_id>` with an actual ID).
    *   Verify the response status is `200 OK` and the response body contains the details of the requested user, like:
        
        ```json
        {
            "user": {
                "id": 1,
                "name": "Jane Doe",
                "email": "jane.doe@example.com",
                "phone": "5511999998888",
                "createdAt": "2025-06-10T10:00:00.000Z",
                "updatedAt": "2025-06-10T10:00:00.000Z"
            }
        }
        ```

5.  **User Not Found (Non-existent ID):**
    *   Send a `GET` request to `http://localhost:3333/users/99999` (or any non-existent ID).
    *   Verify the response status is `404 Not Found` and the error message is `User not found`.
6.  **Invalid ID Parameter (Non-numeric):**
    *   Send a `GET` request to `http://localhost:3333/users/xyz`.
    *   Verify the response status is `400 Bad Request` and the error message reflects a Zod validation error for the `id` parameter.

## Issues Related

N/A